### PR TITLE
Upgrade codesniffer to 4.x

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -4,10 +4,6 @@
     <file>./cli/</file>
     <file>./src/</file>
 
-    <exclude-pattern>*.(css|js)$</exclude-pattern>
-
-    <arg name="extensions" value="php" />
-
     <rule ref="Squiz.ControlStructures.ControlSignature">
         <properties>
             <property name="requiredSpacesBeforeColon" value="0" />

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
   "require-dev": {
     "phpstan/phpstan": "^2.0",
     "brainmaestro/composer-git-hooks": "^3.0",
-    "squizlabs/php_codesniffer": "^3.10",
+    "squizlabs/php_codesniffer": "^4.0",
     "phpmd/phpmd": "3.x-dev",
     "pdepend/pdepend": "3.x-dev",
     "phpbench/phpbench": "^1.4",
@@ -72,6 +72,7 @@
     "check-code": "vendor/bin/phpcs && vendor/bin/phpstan",
     "phpmd": "vendor/bin/phpmd --ignore-violations-on-exit --ignore-errors-on-exit src text phpmd.xml" ,
     "phpstan": "vendor/bin/phpstan",
+    "phpcs": "vendor/bin/phpcs",
     "phpcbf": "vendor/bin/phpcbf",
     "churn": "vendor/bin/churn",
     "twig-lint": "vendor/bin/twig-cs-fixer lint templates",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c92e45685d2e173d8b3540ce62588d3",
+    "content-hash": "42291fc24e8d16f26572bf951ce239c6",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -3664,26 +3664,26 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
             },
             "bin": [
                 "bin/phpcbf",
@@ -3708,7 +3708,7 @@
                     "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
             "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
@@ -3739,7 +3739,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2025-11-10T16:43:36+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
## Linked Issue(s)

Fixes #64

## Summary of Changes

Upgrades PHPCodesniffer to latest release and removes configuration that isn't needed.

## Testing

Ran codesniffer locally to confirm no deprecation messages.

## Breaking Changes / Migration Notes

(If applicable, describe any backward-incompatible changes and provide instructions for upgrading.)

- [ ] This change introduces breaking changes.
- [x] No breaking changes.