### PR TITLE
Feature/98 add sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 /docker/data/*.rdb
 tmp/
 /.twig-cs-fixer.cache
+data/spacetraders.sqlite

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
     "ext-readline": "*",
     "ext-curl": "*",
     "ext-apcu": "*",
+    "ext-pdo": "*",
+    "ext-pdo_sqlite": "*",
+    "ext-sqlite3": "*",
     "minicli/minicli": "^4.2",
     "php-di/php-di": "^7.0",
     "guzzlehttp/guzzle": "^7.8",
@@ -46,7 +49,8 @@
     "lcobucci/jwt": "^5.5",
     "roave/better-reflection": "6.67.x-dev",
     "twig/twig": "^3.0",
-    "phparch/spacetraders-rest": "0.*"
+    "phparch/spacetraders-rest": "0.*",
+    "doctrine/dbal": "^4.4"
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1",
@@ -84,6 +88,7 @@
     "churn": "vendor/bin/churn",
     "phparkitect": "vendor/bin/phparkitect check",
     "twig-lint": "vendor/bin/twig-cs-fixer lint templates",
-    "twig-lint-fix": "vendor/bin/twig-cs-fixer lint --fix templates"
+    "twig-lint-fix": "vendor/bin/twig-cs-fixer lint --fix templates",
+    "init-db": "sqlite3 data/spacetraders.sqlite < data/init-db.sql"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f72cc9da7b16e3674a5faef79950403d",
+    "content-hash": "08af27fb51fcdfb8fae0ada981b33ef2",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -82,6 +82,160 @@
                 }
             ],
             "time": "2026-03-23T17:38:05+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "4.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/61e730f1658814821a85f2402c945f3883407dec",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1.5",
+                "php": "^8.2",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "14.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.2",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "2.0.7",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "11.5.50",
+                "slevomat/coding-standard": "8.27.1",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "symfony/cache": "^6.3.8|^7.0|^8.0",
+                "symfony/console": "^5.4|^6.3|^7.0|^8.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/4.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-20T08:52:12+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -5742,7 +5896,10 @@
         "php": ">=8.4",
         "ext-readline": "*",
         "ext-curl": "*",
-        "ext-apcu": "*"
+        "ext-apcu": "*",
+        "ext-pdo": "*",
+        "ext-pdo_sqlite": "*",
+        "ext-sqlite3": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/config/services.php
+++ b/config/services.php
@@ -1,12 +1,14 @@
 <?php
 
-use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL;
+use GuzzleHttp\Psr7;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Kevinrob\GuzzleCache\Storage\Psr6CacheStorage;
 use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
-use Doctrine\DBAL;
+use League\Route;
 use Phparch\SpaceTraders;
 use Phparch\SpaceTraders\Data;
+use Phparch\SpaceTraders\Middleware;
 use Phparch\SpaceTraders\Routes;
 use Phparch\SpaceTraders\ServiceContainer;
 use Phparch\SpaceTraders\TwigExtensions;
@@ -62,7 +64,7 @@ return [
         assert(is_string($_ENV['DATABASE_DSN']));
         $dsn = $_ENV['DATABASE_DSN'];
         $dsnParser = new DBAL\Tools\DsnParser();
-        return DriverManager::getConnection($dsnParser->parse($dsn));
+        return DBAL\DriverManager::getConnection($dsnParser->parse($dsn));
     },
     Data\SystemRegistry::class => static function(): Data\SystemRegistry {
         return new Data\SystemRegistry(
@@ -73,7 +75,10 @@ return [
         return new Predis\Client($_ENV['REDIS_URI']);
     },
     GuzzleHttp\Client::class => static function () {
-        if (isset($_ENV['REDIS_CACHE_TTL']) && ctype_digit($_ENV['REDIS_CACHE_TTL'])) {
+        if (
+            isset($_ENV['REDIS_CACHE_TTL'])
+            && ctype_digit($_ENV['REDIS_CACHE_TTL'])
+        ) {
             $ttl = (int) $_ENV['REDIS_CACHE_TTL'];
         } else {
             $ttl = 900;
@@ -106,6 +111,23 @@ return [
             ),
             useAPCu: $_ENV['USE_APCU'] === 1,
         );
+    },
+    Route\Router::class => static function (): Route\Router {
+        $responseFactory = new Psr7\HttpFactory();
+        $strategy = new Route\Strategy\JsonStrategy($responseFactory);
+        $router = new Route\Router();
+        $router->setStrategy($strategy);
+        // Register Middleware Components
+        $router->middleware(
+            new Middleware\Auth(getSpaceTradersToken())
+        );
+        $router->middleware(
+            new Middleware\ExceptionDecorator(
+                ServiceContainer::get(\Twig\Environment::class)
+            )
+        );
+
+        return $router;
     },
     Routes\Mapper::class => static function () {
         return new SpaceTraders\Routes\Mapper(

--- a/config/services.php
+++ b/config/services.php
@@ -1,56 +1,72 @@
 <?php
 
+use Doctrine\DBAL\DriverManager;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Kevinrob\GuzzleCache\Storage\Psr6CacheStorage;
 use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
+use Doctrine\DBAL;
 use Phparch\SpaceTraders;
+use Phparch\SpaceTraders\Data;
 use Phparch\SpaceTraders\Routes;
 use Phparch\SpaceTraders\ServiceContainer;
 use Phparch\SpaceTraders\TwigExtensions;
 use Phparch\SpaceTradersRest\Client;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
-function get_spacetraders_token(): string {
-    $token = $_ENV['SPACETRADERS_TOKEN'];
-    assert(is_string($token));
-    return $token;
+function getSpaceTradersToken(): string {
+    $registry = ServiceContainer::get(Data\SystemRegistry::class);
+    return $registry->getString('spacetraders_token') ?? '';
 }
 
 return [
-    Client\Agents::class => static function() {
+    Client\Agents::class => static function(): Client\Agents {
         return new Client\Agents(
-            get_spacetraders_token(),
+            getSpaceTradersToken(),
             ServiceContainer::get(\GuzzleHttp\Client::class)
         );
     },
-    Client\Contracts::class => static function() {
+    Client\Contracts::class => static function(): Client\Contracts {
         return new Client\Contracts(
-            get_spacetraders_token(),
+            getSpaceTradersToken(),
             ServiceContainer::get(\GuzzleHttp\Client::class)
         );
     },
-    Client\Fleet::class => static function() {
+    Client\Fleet::class => static function(): Client\Fleet {
         return new Client\Fleet(
-            get_spacetraders_token(),
+            getSpaceTradersToken(),
             ServiceContainer::get(\GuzzleHttp\Client::class)
         );
     },
-    Client\ShipActions::class => static function() {
+    Client\ShipActions::class => static function(): Client\ShipActions {
         return new Client\ShipActions(
-            get_spacetraders_token(),
+            getSpaceTradersToken(),
             ServiceContainer::get(\GuzzleHttp\Client::class)
         );
     },
-    Client\ShipTravel::class => static function() {
+    Client\ShipTravel::class => static function(): Client\ShipTravel {
         return new Client\ShipTravel(
-            get_spacetraders_token(),
+            getSpaceTradersToken(),
             ServiceContainer::get(\GuzzleHttp\Client::class)
         );
     },
     Client\Systems::class => static function() {
         return new Client\Systems(
-            get_spacetraders_token(),
+            getSpaceTradersToken(),
             ServiceContainer::get(\GuzzleHttp\Client::class)
+        );
+    },
+    DBAL\Connection::class => static function(): DBAL\Connection {
+        if (!isset($_ENV['DATABASE_DSN'])) {
+            throw new \RuntimeException('Database DSN is not defined');
+        }
+        assert(is_string($_ENV['DATABASE_DSN']));
+        $dsn = $_ENV['DATABASE_DSN'];
+        $dsnParser = new DBAL\Tools\DsnParser();
+        return DriverManager::getConnection($dsnParser->parse($dsn));
+    },
+    Data\SystemRegistry::class => static function(): Data\SystemRegistry {
+        return new Data\SystemRegistry(
+            ServiceContainer::get(DBAL\Connection::class),
         );
     },
     Predis\Client::class => static function () {

--- a/data/init-db.sql
+++ b/data/init-db.sql
@@ -1,0 +1,44 @@
+CREATE TABLE registry_text (
+    name TEXT PRIMARY KEY UNIQUE,
+    val TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER update_registry_text_timestamp
+AFTER UPDATE ON registry_text
+BEGIN
+    UPDATE registry_text
+    SET updated_at = CURRENT_TIMESTAMP
+    WHERE name = OLD.name;
+END;
+
+CREATE TABLE registry_int (
+    name TEXT PRIMARY KEY UNIQUE,
+    val INTEGER,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER update_registry_int_timestamp
+AFTER UPDATE ON registry_int
+BEGIN
+    UPDATE registry_int
+    SET updated_at = CURRENT_TIMESTAMP
+    WHERE name = OLD.name;
+END;
+
+CREATE TABLE registry_bool (
+    name TEXT PRIMARY KEY UNIQUE,
+    val BOOL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER update_registry_bool_timestamp
+AFTER UPDATE ON registry_bool
+BEGIN
+    UPDATE registry_bool
+    SET updated_at = CURRENT_TIMESTAMP
+    WHERE name = OLD.name;
+END;

--- a/src/Controller/TokenRenewController.php
+++ b/src/Controller/TokenRenewController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Phparch\SpaceTraders\Controller;
+
+use GuzzleHttp\Psr7;
+use Phparch\SpaceTraders\Attribute\Route;
+use Phparch\SpaceTraders\Controller\Trait\RequestAwareController;
+use Phparch\SpaceTraders\Data\SystemRegistry;
+use Phparch\SpaceTraders\Interface\RequestAware;
+use Phparch\SpaceTraders\Interface\TwigAware;
+use Psr\Http\Message\ResponseInterface;
+
+class TokenRenewController implements RequestAware, TwigAware
+{
+    use RequestAwareController;
+    use Trait\TwigAwareController;
+
+    public function __construct(
+        private SystemRegistry $registry,
+    ) {
+    }
+
+    #[Route(
+        name: 'get-new-token',
+        path: '/get-new-token',
+        methods: ['GET'],
+        strategy: 'application'
+    )]
+    public function getNewToken(): ResponseInterface
+    {
+        return $this->render('get-new-token.html.twig', [
+        ]);
+    }
+
+    #[Route(
+        name: 'save-new-token',
+        path: '/get-new-token',
+        methods: ['POST'],
+        strategy: 'application'
+    )]
+    public function saveNewToken(): ResponseInterface
+    {
+        /**
+         * @var array{token?:string} $post
+         */
+        $post = (array) $this->getRequest()->getParsedBody();
+        $token = trim($post['token'] ?? '');
+        if (!$token) {
+            return new Psr7\Response(
+                status: 303, // Ensure GET
+                headers: ['Location' => '/get-new-token']
+            );
+        }
+        $this->registry->storeText('spacetraders_token', $token);
+        return new Psr7\Response(
+            status: 303, // Ensure GET
+            headers: ['Location' => '/']
+        );
+    }
+}

--- a/src/Data/KeyValueStore.php
+++ b/src/Data/KeyValueStore.php
@@ -3,6 +3,7 @@
 namespace Phparch\SpaceTraders\Data;
 
 use Doctrine\DBAL;
+use Doctrine\DBAL\Exception;
 
 class KeyValueStore
 {
@@ -19,13 +20,6 @@ class KeyValueStore
     ) {
     }
 
-    private function queryTable(string $type, string $key): DBAL\Result {
-        return $this->db->executeQuery(
-            "SELECT val FROM `{$this->table_prefix}_{$type}` WHERE `name` = :key",
-            [strtolower($key)],
-            [DBAL\ParameterType::STRING]
-        );
-    }
     public function getString(string $key): ?string {
 
         if (isset($this->cache_string[$key])) {
@@ -70,6 +64,51 @@ class KeyValueStore
         return $default;
     }
 
-    public function store(string $key, mixed $value): void {
+    /**
+     * @throws Exception
+     */
+    public function storeText(string $key, string $value): int {
+        return $this->insertValue('text', $key, $value);
+    }
+
+    public function storeInt(string $key, int $value): int {
+        return $this->insertValue('int', $key, $value);
+    }
+
+    public function storeBool(string $key, bool $value): int {
+        return $this->insertValue('bool', $key, $value);
+    }
+
+    private function queryTable(string $type, string $key): DBAL\Result {
+        return $this->db->executeQuery(
+            "SELECT val FROM `{$this->table_prefix}_{$type}` WHERE `name` = :key",
+            [strtolower($key)],
+            [DBAL\ParameterType::STRING]
+        );
+    }
+
+    /**
+     * @param 'int'|'text'|'bool' $type
+     * @throws Exception
+    */
+    public function insertValue(string $type, string $key, string|bool|int $value): int {
+        $valueType = match ($type) {
+            'text' => DBAL\ParameterType::STRING,
+            'int' => DBAL\ParameterType::INTEGER,
+            'bool' => DBAL\ParameterType::BOOLEAN,
+        };
+        return (int) $this->db->executeStatement(
+            <<<SQL
+            INSERT INTO `{$this->table_prefix}_{$type}` 
+                VALUES (?, ?, null, null)
+                ON CONFLICT(`name`)
+                   DO UPDATE SET `val` = ? WHERE `name` = ?
+            SQL,
+            [
+                strtolower($key), $value, // INSERT
+                $value, strtolower($key) // UPDATE
+            ],
+            [DBAL\ParameterType::STRING, $valueType, DBAL\ParameterType::STRING, $valueType]
+        );
     }
 }

--- a/src/Data/KeyValueStore.php
+++ b/src/Data/KeyValueStore.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Phparch\SpaceTraders\Data;
+
+use Doctrine\DBAL;
+
+class KeyValueStore
+{
+    /** @var array<string, string>  */
+    private $cache_string = [];
+    /** @var array<string, ?int>  */
+    private $cache_int = [];
+    /** @var array<string, ?bool>  */
+    private $cache_bool = [];
+
+    public function __construct(
+        private DBAL\Connection $db,
+        private readonly string $table_prefix,
+    ) {
+    }
+
+    private function queryTable(string $type, string $key): DBAL\Result {
+        return $this->db->executeQuery(
+            "SELECT val FROM `{$this->table_prefix}_{$type}` WHERE `name` = :key",
+            [strtolower($key)],
+            [DBAL\ParameterType::STRING]
+        );
+    }
+    public function getString(string $key): ?string {
+
+        if (isset($this->cache_string[$key])) {
+            return $this->cache_string[$key];
+        }
+
+        $result = $this->queryTable('text', $key);
+        if ($value = $result->fetchOne()) {
+            /** @var scalar $value */
+            $this->cache_string[$key] = (string) $value;
+            return (string) $value;
+        }
+        $this->cache_int[$key] = null;
+        return null;
+    }
+
+    public function getInt(string $key): ?int {
+        if (isset($this->cache_int[$key])) {
+            return $this->cache_int[$key];
+        }
+        $result = $this->queryTable('int', $key);
+        if ($value = $result->fetchOne()) {
+            /** @var scalar $value */
+            $this->cache_int[$key] = (int) $value;
+            return (int) $value;
+        }
+        $this->cache_int[$key] = null;
+        return null;
+    }
+
+    public function getBool(string $key, ?bool $default = null): ?bool {
+        if (isset($this->cache_bool[$key])) {
+            return $this->cache_bool[$key];
+        }
+        $result = $this->queryTable('bool', $key);
+        if ($value = $result->fetchOne()) {
+            /** @var scalar $value */
+            $this->cache_bool[$key] = (bool) $value;
+            return (bool) $value;
+        }
+        $this->cache_bool[$key] = $default;
+        return $default;
+    }
+
+    public function store(string $key, mixed $value): void {
+    }
+}

--- a/src/Data/SystemRegistry.php
+++ b/src/Data/SystemRegistry.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Phparch\SpaceTraders\Data;
+
+use Doctrine\DBAL;
+
+class SystemRegistry extends KeyValueStore
+{
+    public function __construct(
+        private DBAL\Connection $db,
+    ) {
+        parent::__construct(
+            $this->db,
+            'registry'
+        );
+    }
+}

--- a/src/Middleware/Auth.php
+++ b/src/Middleware/Auth.php
@@ -10,6 +10,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Token\Parser;
 use League\Route\Http\Exception\UnauthorizedException;
+use GuzzleHttp\Psr7;
 
 class Auth implements MiddlewareInterface
 {
@@ -25,6 +26,10 @@ class Auth implements MiddlewareInterface
         ServerRequestInterface $request,
         RequestHandlerInterface $handler
     ): ResponseInterface {
+        if ($request->getRequestTarget() === '/get-new-token') {
+            return $handler->handle($request);
+        }
+
         if ($this->token) {
             try {
                 $parser = new Parser(new JoseEncoder());
@@ -35,12 +40,17 @@ class Auth implements MiddlewareInterface
                     return $handler->handle($request);
                 }
             } catch (InvalidTokenStructure $e) {
-                throw new UnauthorizedException(
-                    'Unauthorized: ' . $e->getMessage(),
-                    previous: $e
-                );
+                // Send users to store a new token
+                return $this->redirect();
             }
         }
-        throw new UnauthorizedException('Unauthorized: No token found.');
+        return $this->redirect();
+    }
+
+    private function redirect(): ResponseInterface {
+        return new Psr7\Response(
+            status: 307,
+            headers: ['Location' => '/get-new-token']
+        );
     }
 }

--- a/templates/get-new-token.html.twig
+++ b/templates/get-new-token.html.twig
@@ -1,0 +1,18 @@
+{% import 'macros/helpers.html.twig' as helpers %}
+{% extends 'minimal.html.twig' %}
+
+{% block content %}
+
+<h1>Please Authenticate your Agent</h1>
+<p>The SpaceTraders API token is missing or invalid.
+    Please go to<a href="https://my.spacetraders.io/agents">your Agents page</a>
+    and generate a new one.</p>
+<form method="post">
+    <input type="password"
+           placeholder="API Token"
+           name="token"
+           size="60"
+           required="required">
+    <input type="submit" value="Save Token">
+</form>
+{% endblock %}

--- a/web/index.php
+++ b/web/index.php
@@ -3,7 +3,6 @@
 use GuzzleHttp\Psr7;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use League\Route;
-use Phparch\SpaceTraders\Middleware;
 use Phparch\SpaceTraders\Routes\Mapper;
 use Phparch\SpaceTraders\ServiceContainer;
 
@@ -21,15 +20,7 @@ ServiceContainer::autodiscover();
 
 $request = Psr7\ServerRequest::fromGlobals();
 
-$responseFactory = new Psr7\HttpFactory();
-$strategy = new Route\Strategy\JsonStrategy($responseFactory);
-$router   = (new Route\Router)->setStrategy($strategy);
-// Register Middleware Components
-$router->middleware(new Middleware\Auth($_ENV["SPACETRADERS_TOKEN"] ?? ''));
-$router->middleware(new Middleware\ExceptionDecorator(
-    ServiceContainer::get(\Twig\Environment::class)
-));
-
+$router = ServiceContainer::get(Route\Router::class);
 $mapper = ServiceContainer::get(Mapper::class);
 $router = $mapper->registerAll($router);
 


### PR DESCRIPTION
## Linked Issue(s)

Adds SQL lite for persisting data.

Fixes #98 

## Summary of Changes

Adds SQL lite and access to it via Doctrine DB Access Layer

## Testing

PHPStan and click-testing

## Breaking Changes / Migration Notes

(If applicable, describe any backward-incompatible changes and provide instructions for upgrading.)

- [ ] This change introduces breaking changes.
- [x] No breaking changes.