### PR TITLE
Explicitly sets the created_at, updated_at columns in key value stores.

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -112,7 +112,9 @@ return [
         return new GuzzleHttp\Client(['handler' => $stack]);
     },
     ListenerProviderInterface::class => static function(): ListenerProviderInterface {
-        $provider =new \Crell\Tukio\OrderedListenerProvider();
+        $provider =new \Crell\Tukio\OrderedListenerProvider(
+            ServiceContainer::instance()
+        );
         // register events based on attributes on methods in ListenerService
         $provider->listenerService(SpaceTraders\Event\ListenerService::class);
         return $provider;

--- a/src/Data/KeyValueStore.php
+++ b/src/Data/KeyValueStore.php
@@ -100,9 +100,9 @@ class KeyValueStore
         return (int) $this->db->executeStatement(
             <<<SQL
             INSERT INTO `{$this->table_prefix}_{$type}` 
-                VALUES (?, ?, null, null)
+                VALUES (?, ?, datetime('now'), datetime('now'))
                 ON CONFLICT(`name`)
-                   DO UPDATE SET `val` = ? WHERE `name` = ?
+                   DO UPDATE SET `val` = ?, updated_at=datetime('now') WHERE `name` = ?
             SQL,
             [
                 strtolower($key), $value, // INSERT


### PR DESCRIPTION
## Linked Issue(s)

Please include the issue number that this PR addresses. This helps track the completion of the original task.

Fixes #110 g (e.g., Fixes #42, Resolves #101)

## Summary of Changes

Explicitly sets the created_at, updated_at columns in key value stores.

## Testing

Step through update, checked in DB that columns have values.

## Breaking Changes / Migration Notes

(If applicable, describe any backward-incompatible changes and provide instructions for upgrading.)

- [ ] This change introduces breaking changes.
- [x] No breaking changes.